### PR TITLE
Generate lowercased hex letters

### DIFF
--- a/devid_all_platforms.go
+++ b/devid_all_platforms.go
@@ -9,7 +9,7 @@ import (
 
 // generateDeviceID generates values in the format of:
 // `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`
-// Where 'x' is any legal hex digit.
+// Where 'x' is any legal lowercased hex digit.
 func generateDeviceID() (string, error) {
 	randBytes := make([]byte, 4+2+2+2+6)
 
@@ -18,7 +18,7 @@ func generateDeviceID() (string, error) {
 	}
 
 	// (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)
-	return fmt.Sprintf("%0X-%0X-%0X-%0X-%0X",
+	return fmt.Sprintf("%x-%x-%x-%x-%x",
 		randBytes[0:4],
 		randBytes[4:6],
 		randBytes[6:8],

--- a/devid_all_platforms_test.go
+++ b/devid_all_platforms_test.go
@@ -45,15 +45,6 @@ func TestGenerateDevID(t *testing.T) {
 
 		t.Logf("Generated ID = %s", id)
 		requireValidGUID(t, id)
-		parts := strings.Split(id, "-")
-		require.Equal(t, 5, len(parts))
-
-		// 8-4-4-4-12
-		require.Equal(t, 8, len(parts[0]))
-		require.Equal(t, 4, len(parts[1]))
-		require.Equal(t, 4, len(parts[2]))
-		require.Equal(t, 4, len(parts[3]))
-		require.Equal(t, 12, len(parts[4]))
 	})
 }
 
@@ -112,4 +103,11 @@ func requireValidGUID(t *testing.T, id string) {
 	require.Equal(t, 4, len(parts[2]))
 	require.Equal(t, 4, len(parts[3]))
 	require.Equal(t, 12, len(parts[4]))
+
+	// all lowercased hex
+	for _, part := range parts {
+		for _, c := range part {
+			require.True(t, (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f'))
+		}
+	}
 }


### PR DESCRIPTION
Update `generateDeviceID` to only generate lowercase letters.

This is based on the requirement:

> The value shall be all lowercase and only contain hyphens. No braces or brackets.  
 > Example: In C#, this can be generated by calling Guid.NewGuid().ToString("D").ToLowerInvariant() 